### PR TITLE
Anpassung für Windows  (ohne gpio)

### DIFF
--- a/Windows_requirements.txt
+++ b/Windows_requirements.txt
@@ -11,9 +11,9 @@ greenlet==0.4.7
 itsdangerous==0.24
 Jinja2==2.7.3
 MarkupSafe==0.23
-##RPi.GPIO==0.5.11  nicht für Windows
+##RPi.GPIO==0.5.11  nicht fÃ¼r Windows
 SQLAlchemy==1.0.4
 Werkzeug==0.10.4
 wheel==0.24.0
 WTForms==2.0.2
-Flask-Babel=0.9
+Flask-Babel==0.9

--- a/Windows_requirements.txt
+++ b/Windows_requirements.txt
@@ -1,0 +1,19 @@
+blinker==1.3
+Flask==0.10.1
+Flask-Admin==1.1.0
+Flask-DebugToolbar==0.10.0
+Flask-SocketIO==0.6.0
+Flask-SQLAlchemy==2.0
+gevent==1.0.2
+gevent-socketio==0.3.6
+gevent-websocket==0.9.5
+greenlet==0.4.7
+itsdangerous==0.24
+Jinja2==2.7.3
+MarkupSafe==0.23
+##RPi.GPIO==0.5.11  nicht für Windows
+SQLAlchemy==1.0.4
+Werkzeug==0.10.4
+wheel==0.24.0
+WTForms==2.0.2
+Flask-Babel=0.9

--- a/brewapp/__init__.py
+++ b/brewapp/__init__.py
@@ -3,24 +3,32 @@ from flask_debugtoolbar import DebugToolbarExtension
 from flask.ext.admin import Admin
 from flask import Flask, render_template
 from flask.ext.socketio import SocketIO, emit
-from subprocess import call
+from subprocess import call, Popen, PIPE
 import json
+import shlex
 
 app = Flask(__name__)
 socketio = SocketIO(app)
 
-try:
-	call(["modprobe", "w1-gpio"])
-	call(["modprobe", "w1-therm"])
-except:
-	print "ModeProbe Failed"
+import brewapp.globalprops
 
-
-
+if globalprops.owfsWin != True:
+        try:
+             call(["modprobe", "w1-gpio"])
+       	     call(["modprobe", "w1-therm"])
+        except:
+             print "ModeProbe Failed"
+else:        	
+     try:
+          cmd ='C:/Programme/OWFS/bin/owserver.exe -u -p 3000 --timeout_volatile=2'
+          args = shlex.split(cmd)
+          spipe = Popen(args, stdout = False)
+     except:
+          print "OWS Failed"
+   
 
 import brewapp.banner
 import brewapp.model
-import brewapp.globalprops
 
 import brewapp.gpio
 import brewapp.job

--- a/brewapp/globalprops.py
+++ b/brewapp/globalprops.py
@@ -1,7 +1,10 @@
 from brewapp.model import db, Step, Temperatur, Log, Config, getAsArray
 from Queue import Queue
 ## if test mode
-testMode = True
+testMode = False
+
+owfsWin = True
+
 ###################################################################
 #### INTERNAL DO NOT CHANGE PARAMETERS BELOW
 gpioMode = True

--- a/brewapp/model.py
+++ b/brewapp/model.py
@@ -234,4 +234,4 @@ if(db_exists == False):
     addConfig("pid_agitator", "True")
     addConfig("temp_db_interval", "5")
     addConfig("brew_name", "Beispiel Sud")
-    addConfig("tempSensorId1", "{\"name\": \"P22\", \"id\": \"28-03146215acff\"}")
+    addConfig("tempSensorId1", "{\"name\": \"P1\", \"id\": \"28.6B162B060000\"}")

--- a/brewapp/thermometer.py
+++ b/brewapp/thermometer.py
@@ -5,21 +5,28 @@ from subprocess import Popen, PIPE, call
 ## Method to read the temperatur
 def tempData1Wire(tempSensorId):
 
-    ## Test Mode
+    if globalprops.owfsWin == True:
+         pipe = Popen(["C:\\Programme\\OWFS\\bin\\owread", "-s", ":3000","/" + tempSensorId + "/temperature"], shell=False,stdout=PIPE)
+    else:     
+        ## Test Mode
 
-    if (globalprops.testMode == True):
-        pipe = Popen(["cat","w1_slave"], stdout=PIPE)
-    ## GPIO Mode
-    else:
-        pipe = Popen(["cat","/sys/bus/w1/devices/w1_bus_master1/" + tempSensorId + "/w1_slave"], stdout=PIPE)
+        if (globalprops.testMode == True):
+            pipe = Popen(["cat","w1_slave"], stdout=PIPE)
+        ## GPIO Mode
+        else:
+            pipe = Popen(["cat","/sys/bus/w1/devices/w1_bus_master1/" + tempSensorId + "/w1_slave"], stdout=PIPE)
 
     result = pipe.communicate()[0]
 
     ## parse the file
-    if (result.split('\n')[0].split(' ')[11] == "YES"):
-        temp_C = float(result.split("=")[-1])/1000 # temp in Celcius
-
+    if globalprops.owfsWin == True: 
+        temp_C = float(result)
+        print str(temp_C)
     else:
-        temp_C = -99 #bad temp reading
+       if (result.split('\n')[0].split(' ')[11] == "YES"):
+           temp_C = float(result.split("=")[-1])/1000 # temp in Celcius
+
+       else:
+           temp_C = -99 #bad temp reading
 
     return temp_C


### PR DESCRIPTION
craftbeerpi läuft mit minimalen Anpassungen auch auf Windows als
Monitoring ohne Steuerung der Heizung

