### PR TITLE
Update overshoot_advanced.py

### DIFF
--- a/brewapp/base/automatic/overshoot_advanced.py
+++ b/brewapp/base/automatic/overshoot_advanced.py
@@ -42,7 +42,7 @@ class OvershootLogic_by_Norn(Automatic):
             if(currentTemp >= targetTemp and self.state == True and targetTemp == self.setpoint):
                 self.state = False
                 self.switchHeaterOFF()
-            time.sleep(1)
+            socketio.sleep(1)
 
         self.switchHeaterOFF()
         app.logger.info("Stop PID - Kettle Id: "+ str(self.kid))


### PR DESCRIPTION
changed time.sleep(1) to socketio.sleep(1) in line 45 as time.sleep(1) is no longer working.
See also http://hobbybrauer.de/forum/viewtopic.php?f=58&t=3959&p=164212&hilit=advanced#p164212
