### PR TITLE
Add basic PWM "automatic"

### DIFF
--- a/brewapp/base/automatic/__init__.py
+++ b/brewapp/base/automatic/__init__.py
@@ -7,3 +7,4 @@ import overshoot_advanced
 import hyteresis
 import hendipid
 import hendipowerctrl
+import pwm

--- a/brewapp/base/automatic/pwm.py
+++ b/brewapp/base/automatic/pwm.py
@@ -1,0 +1,37 @@
+import time
+from brewapp import app, socketio
+
+from automaticlogic import *
+
+@brewautomatic()
+class PWM(Automatic):
+
+    configparameter = [
+    {"name":"Duty Cycle(%)", "value":50},
+	{"name":"Period(s)", "value":10},
+	{"name":"Use Temp Setpoint As Duty Cycle","value":0}]
+	
+
+    def run(self):
+	period = float(self.config["Period(s)"])
+	dutycycle = float(self.config["Duty Cycle(%)"])
+        
+    	while self.isRunning():
+		if float(self.config["Use Temp Setpoint As Duty Cycle"]) == 0:
+			heating_time = period * dutycycle / 100
+		else:
+			temp_setpoint = self.getTargetTemp()
+			if temp_setpoint > 100:
+				temp_setpoint = 100
+			elif temp_setpoint < 0:
+				temp_setpoint = 0
+				
+			heating_time = period * temp_setpoint / 100
+			
+		wait_time = period - heating_time
+        	self.switchHeaterON()
+        	socketio.sleep(heating_time)
+        	self.switchHeaterOFF()
+        	socketio.sleep(wait_time)
+   
+        self.switchHeaterOFF()


### PR DESCRIPTION
Add a control logic module (pwm.py) to provide basic PWM output control. If the "Use Temp Setpoint As Duty Cycle" is non zero then temp setpoint sets the duty cycle. It's a bit ugly but more convenient then going into configuration repeatedly.