### PR TITLE
PipForceSSL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ easy_install pip
 #Install Flask
 apt-get -y install python-dev
 apt-get -y install libpcre3-dev
-pip install -r requirements.txt
+pip install --index-url=https://pypi.python.org/simple/ -r requirements.txt
 
 
 if ! grep -q "dtoverlay=w1-gpio" "/boot/config.txt"; then


### PR DESCRIPTION
Fixes issues with the install shell script and pip-based install depedencies not being installed due to the pip issue. 

Forces SSL for the pip index due to older version of pip installed via
easy_install