### PR TITLE
Add support for DS9097 Thermometers through digitemp

### DIFF
--- a/brewapp/base/config.py
+++ b/brewapp/base/config.py
@@ -88,7 +88,8 @@ def initDriver():
         'DUMMY': dummy_thermometer.DummyThermometer(),
         '1WIRE': w1_thermometer.OneWireThermometer(),
         '1WIRE_V2': w1_thermometer2.OneWireThermometer2(),
-        'USB': usb_thermometer.USBThermometer()
+        'USB': usb_thermometer.USBThermometer(),
+        'DS9097': ds9097_thermometer.DS9097Thermometer()
     }
 
     app.brewapp_hardware = hardware.get(app.brewapp_config.get("SWITCH_TYPE", "DUMMY"), dummygpio.DummyGPIO())

--- a/brewapp/base/thermometer/__init__.py
+++ b/brewapp/base/thermometer/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["w1_thermometer", "w1_thermometer2", "dummy_thermometer", "usb_thermometer"]
+__all__ = ["w1_thermometer", "w1_thermometer2", "dummy_thermometer", "usb_thermometer", "ds9097_thermometer"]

--- a/brewapp/base/thermometer/ds9097_thermometer.py
+++ b/brewapp/base/thermometer/ds9097_thermometer.py
@@ -1,0 +1,73 @@
+import os
+from subprocess import Popen, PIPE, call
+import shlex
+from random import randint, uniform
+from brewapp import app
+from decimal import Decimal, ROUND_HALF_UP
+import os.path
+from glob import glob
+
+class DS9097Thermometer(object):
+
+    def init(self):
+        try:
+            port = app.brewapp_config['THERM_DS9097_PORT']
+            if not port or not os.path.exists(port):
+                port = glob('/dev/ttyUSB*')[0]
+                if not port:
+                    app.logger.warn("Could not find %s or and /dev/ttyUSB*, exiting",
+                                    app.brewapp_config['THERM_DS9097_PORT'])
+                app.logger.warn("Could not find %s, using %s instead",
+                                 app.brewapp_config['THERM_DS9097_PORT'], port)
+
+            init_proc = Popen(shlex.split(
+                'digitemp_DS9097 -q -s %s -i'%port
+                ), stdout=PIPE, stderr=PIPE)
+            ret = init_proc.wait()
+            if ret != 0:
+                app.logger.warning("Could not find sensors: \n'''\n%s\n%s\n'''\n",
+                        init_proc.stdout.read(), init_proc.stderr.read())
+
+        except Exception as e:
+            app.logger.warning("Could not find sensors: %s", e)
+
+    def readAllSensors(self):
+        find_proc = Popen(shlex.split(
+            'digitemp_DS9097 -q -o 2 -a'
+            ), stdout=PIPE, stderr=PIPE)
+        retVal = find_proc.wait()
+        if retVal != 0:
+            app.logger.warning("Could not enumerate sensors: \n'''\n%s\n%s\n'''\n",
+                    find_proc.stdout.read(), find_proc.stderr.read())
+            return {}
+
+        ret = {}
+        for line in find_proc.stdout.readlines():
+            try:
+                sid, temp = [x.strip().replace('\n', '') for x in line.split('\t', 1)]
+                sid = "DS9097-%s"%sid
+                temp = float(temp)
+            except Exception as e:
+                app.logger.warning("Could not enumerate sensors: %s", e)
+                return {}
+            ret[sid] = temp
+        return ret
+
+
+    def getSensors(self):
+        try:
+            sensors = self.readAllSensors()
+            return list(sensors.keys())
+        except:
+            return []
+
+    def readTemp(self, tempSensorId):
+        try:
+            ## Test Mode
+            if(tempSensorId == None or tempSensorId == ""):
+                return None
+            sensors = self.readAllSensors()
+            return sensors[tempSensorId]
+        except Exception as e:
+            app.logger.warning("Could not read temp sensor %s: %s", tempSensorId, e)
+            return None

--- a/brewapp/ui/static/partials/setup/thermotype.html
+++ b/brewapp/ui/static/partials/setup/thermotype.html
@@ -3,8 +3,6 @@
 
 
 <div class="row">
-       <div class="col-sm-3 ">
-           </div>
     <div class="col-sm-3 ">
         <div class="thumbnail ">
             <img class="img-responsive" src="static/images/1wire.png"/>
@@ -12,6 +10,16 @@
                 <h3>1Wire</h3>
                 <p></p>
                 <button type="button" class="btn btn-primary" ng-click="setThermometer('1WIRE')">Select</button>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-3 ">
+        <div class="thumbnail ">
+            <img class="img-responsive" src="static/images/1wire.png"/>
+            <div class="caption">
+                <h3>USB-Serial 1Wire (DS9097)</h3>
+                <p></p>
+                <button type="button" class="btn btn-primary" ng-click="setThermometer('DS9097')">Select</button>
             </div>
         </div>
     </div>
@@ -25,8 +33,6 @@
             </div>
         </div>
     </div>
-    <div class="col-sm-3 ">
-           </div>
 
 
 </div>

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,7 +18,7 @@ UNIT:
 
 THERMOMETER_TYPE:
  value: 1WIRE
- options: ['1WIRE','USB','DUMMY', '1WIRE_V2']
+ options: ['1WIRE','USB','DUMMY', '1WIRE_V2', 'DS9097']
  description: 'Thermometer Type !!!RESTART AFTER CHANGE OF THIS PARAMETER!!!'
 
 SWITCH_TYPE:
@@ -71,3 +71,8 @@ WIFI_SOCKET_USER:
 WIFI_SOCKET_PASSWORD:
   value: 12345
   description: 'password for wifi socket'
+
+THERM_DS9097_PORT:
+  value: '/dev/ttyUSB0'
+  description: 'Serial-port devicefile to use for DS9097-communication. e.g. /dev/ttyUSB* or /dev/ttyS*'
+

--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,16 @@ while true; do
     esac
 done
 
+while true ; do
+    read -p "Would you like to install digitemp? This is required for DS9097 1Wire Adaptors (y/n): " yn
+    case $yn in
+        [Yy]* ) apt-get -y install digitemp;
+        break;;
+        [Nn]* ) break;;
+        * ) echo "(Y/N)";;
+    esac
+done
+
 #Install pip (package installer):
 apt-get -y install python-setuptools
 easy_install pip


### PR DESCRIPTION
I recently bought a used brewing set, which came with a RbPi3, and a DS9097-based thermometer setup. Since I’d like to use CraftBeerPi with it, i figured out a way to add support for this USB->Serial->1W->Thermometer chain.

I used the popular digitemp package to read from the sensors. I guess for this change to be useful, i’d also need to change the frontend code to be able to configure it, as well as add a prompt to install digitemp — which is included in raspbian and many other distributions! — to the installer script.

Please let me know what you think, and how you’d like the rest of this structured.
Best Regards & Thank for your great work!
-Dario