### PR TITLE
Update WiringPi git location in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ done
 while true; do
     read -p "Would you like to install wiringPI? This is required to control the GPIO (y/n): " yn
     case $yn in
-        [Yy]* ) git clone git://git.drogon.net/wiringPi;
+        [Yy]* ) git clone https://github.com/wiringPi/wiringPi;
         cd wiringPi;
         ./build; cd ..;
         rm -rf wiringPi;


### PR DESCRIPTION
Replace the wiringPi git link with an unofficial one, as the original been discontinued and does not work.